### PR TITLE
use openmpi for parallelization

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,44 @@
+name: deploy docs to gh-page
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: install tox
+        run: pip install --upgrade tox
+      - name: setup pages
+        uses: actions/configure-pages@v2
+      - name: build docs
+        run: tox -e docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: deploy to gh-pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
 set(ModuleName "_thermal_comfort")
 # we can add -ffast-math if we do the checking for NaNs in python
 set(CMAKE_Fortran_FLAGS
-    "${CMAKE_Fortran_FLAGS} -Ofast -Wall -march=native -ftree-vectorize -funroll-loops -flto"
+    "${CMAKE_Fortran_FLAGS} -Ofast -Wall -march=native -ftree-vectorize -funroll-loops -flto -fopenmp"
 )
 find_package(
   Python

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ via ssh
 pip install git+ssh://git@github.com/RUBclim/thermal-comfort
 ```
 
+## Documentation
+
+Docs can be found here: https://rubclim.github.io/thermal-comfort/
+
 ## Run the tests
 
 On version 3.12 for example...


### PR DESCRIPTION
This should significantly speedup PET-calculation for large rasters. However, it also creates a significant overhead for smaller calculations we should have a threshold for when to use OMP and when to only use a single thread to minimize overhead.
Also here we could move the nan-checker to python and only to that once and not once per-iteration.

This results in these performance changes to the baseline (the main branch):

Then benchmark was ran using an array of 1,000,000 values and 4 threads
- Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
- ubuntu 24.04 in a Virtualbox VM

| Benchmark      | baseline |            omp             |
| -------------- | :------: | :------------------------: |
| tmrt scalar    | 2.01 us  |   4.14 us: 2.06x slower    |
| tmrt array     |  149 ms  | **6.79 ms: 21.95x faster** |
| twb scalar     | 1.12 us  |   1.82 us: 1.63x slower    |
| twb array      | 40.9 ms  | **1.43 ms: 28.66x faster** |
| utci scalar    | 20.4 us  |   22.9 us: 1.12x slower    |
| utci array     |  120 ms  | **5.73 ms: 21.03x faster** |
| pet scalar     | 9.49 us  |   11.2 us: 1.18x slower    |
| pet array      | 9.67 sec | **286 ms: 33.83x faster**  |
| Geometric mean |  (ref)   |      **4.22x faster**      |

