### PR TITLE
speedup calculation by using DO loops instead of array-based operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(
 set(ModuleName "_thermal_comfort")
 # we can add -ffast-math if we do the checking for NaNs in python
 set(CMAKE_Fortran_FLAGS
-    "${CMAKE_Fortran_FLAGS} -Ofast -Wall -march=native -ftree-vectorize -funroll-loops -flto"
+    "${CMAKE_Fortran_FLAGS} -Ofast -Wall -march=native -ftree-vectorize -funroll-loops -funsafe-math-optimizations"
 )
 find_package(
   Python

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -69,6 +69,18 @@ def main() -> int:
         setup=f'from thermal_comfort import heat_index\n{array_setup}',
     )
 
+    runner.timeit(
+        name='heat index extended scalar',
+        stmt='heat_index_extended(ta=20, rh=50)',
+        setup='from thermal_comfort import heat_index_extended',
+    )
+
+    runner.timeit(
+        name='heat index extended array',
+        stmt='heat_index_extended(ta=ta, rh=rh)',
+        setup=f'from thermal_comfort import heat_index_extended\n{array_setup}',
+    )
+
     # UTCI
     runner.timeit(
         name='utci scalar',

--- a/tests/thermal_comfort_test.py
+++ b/tests/thermal_comfort_test.py
@@ -500,10 +500,10 @@ def test_heat_index_scalar_values(f, ta, rh, expected):
 @pytest.mark.parametrize(
     ('ta', 'rh', 'expected'),
     (
-        (35, 10, 32.333),
+        (35, 10, 31.916),
         (30, 90, 40.774),
         # with fahrenheit conditions
-        (_f2c(95), 10, 32.333),
+        (_f2c(95), 10, 31.916),
         (_f2c(86), 90, 40.774),
     ),
 )


### PR DESCRIPTION
This moves from array-based calculations to `DO`, since this seems to be much faster. The compiler flag `-funsafe-math-optimizations` additionally gives another performance gain.